### PR TITLE
province box height changed to auto instead of constant px

### DIFF
--- a/src/components/MainViewContainer.js
+++ b/src/components/MainViewContainer.js
@@ -260,7 +260,7 @@ const MainViewContaier = () => {
         sx={{
           flexGrow: 1,
           marginTop: "30px",
-          height: "500px",
+          height: "auto",
           overflow: "auto",
           textAlign: "center",
         }}


### PR DESCRIPTION
Issue related with box height of provinces resolved.
Before view of component:
![image](https://user-images.githubusercontent.com/51818946/218306855-8179cdb3-ca79-4029-9a83-96aa764375cb.png)
After height of box corrected. ( Height defined as auto in case of more province may included in future )
![image](https://user-images.githubusercontent.com/51818946/218306901-e423993a-1025-4964-b8c4-ff97d3a24e70.png)
